### PR TITLE
Add check for time.h

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,7 @@ AC_CHECK_HEADERS([errno.h \
 		  stddef.h \
 		  stdlib.h \
 		  string.h \
+		  time.h \
 		  sys/types.h])
 
 PKG_CHECK_MODULES([LIBNTFS_3G], [libntfs-3g >= 2017.3.23], [],


### PR DESCRIPTION
ntfs-3g/inode.h includes nfts-3g/ntfstime.h
ntfstime.h checks for HAVE_TIME_H to include <time.h> <time.h> is needed for C99 declarations.

Related to:

  <https://fedoraproject.org/wiki/Changes/PortingToModernC>
  <https://fedoraproject.org/wiki/Toolchain/